### PR TITLE
Allow to define annotations on secrets

### DIFF
--- a/wiz-admission-controller/Chart.yaml
+++ b/wiz-admission-controller/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-admission-controller/templates/opawebhook.yaml
+++ b/wiz-admission-controller/templates/opawebhook.yaml
@@ -46,6 +46,9 @@ metadata:
     # Using helm hook to create certs only for chart install
     "helm.sh/hook": "pre-install, pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    {{- with .Values.opaWebhook.secret.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   tls.crt: {{ $tlsCrt }}
   tls.key: {{ $tlsKey }}

--- a/wiz-admission-controller/templates/proxy.yaml
+++ b/wiz-admission-controller/templates/proxy.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "wiz-admission-controller.proxySecretName" . | trim }}
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
+  {{- with .Values.httpProxyConfiguration.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   http-proxy: {{ .Values.httpProxyConfiguration.httpProxy | b64enc | quote }}
   https-proxy: {{ .Values.httpProxyConfiguration.httpsProxy | b64enc | quote }}

--- a/wiz-admission-controller/templates/secret.yaml
+++ b/wiz-admission-controller/templates/secret.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "wiz-admission-controller.secretApiTokenName" . | trim }}
   labels:
     {{- include "wiz-admission-controller.labels" . | nindent 4 }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   clientId: {{ required "Missing required value wizApiToken.clientId is required" .Values.wizApiToken.clientId | b64enc | quote }}
   clientToken: {{ required "Missing required value: wizApiToken.clientToken is required" .Values.wizApiToken.clientToken | b64enc | quote }}

--- a/wiz-admission-controller/values.yaml
+++ b/wiz-admission-controller/values.yaml
@@ -16,7 +16,8 @@ httpProxyConfiguration:
   #  2. Set secretName to reference your secret
   create: true
   secretName: "" # Overriding default name for proxy secret name (.Release.Name + "-proxy-configuration" by default)
-  
+  # Annotations to be set on the secret
+  annotations: {}
   httpProxy: ""
   httpsProxy: ""
   noProxyAddress: ""
@@ -78,6 +79,9 @@ opaWebhook:
     - "Default IaC policy"
   clusterExternalId: "" # Wiz cluster external id (required only for on-prem and OKE clusters)
 
+  secret:
+    annotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -94,6 +98,8 @@ secret:
   # The name of the secret to use.
   # If not set, a name is generated using the fullname template
   name: ""
+  # Annotations to be set on the secret
+  annotations: {}
 
 podAnnotations: {}
 

--- a/wiz-broker/Chart.yaml
+++ b/wiz-broker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-broker/templates/wiz-broker-deployment.yaml
+++ b/wiz-broker/templates/wiz-broker-deployment.yaml
@@ -40,6 +40,10 @@ kind: Secret
 metadata:
   name: wiz-tunnel-client-{{ include "wiz-broker.wizConnectorID" . }}-cfg
   namespace: {{ .Values.namespace }}
+  {{- with .Values.wizConnector.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   {{- include "wiz-broker.wizConnectorSecretData" . | nindent 2 }}

--- a/wiz-broker/templates/wiz-rbac.yaml
+++ b/wiz-broker/templates/wiz-rbac.yaml
@@ -22,6 +22,9 @@ metadata:
     {{- include "wiz-broker.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/service-account.name: {{ $rbacServiceAccountName }}
+    {{- with .Values.rbacSecret.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/wiz-broker/values.yaml
+++ b/wiz-broker/values.yaml
@@ -12,6 +12,9 @@ rbacServiceAccount:
   name: "wiz-kube-connector"
   annotations: {}
 
+rbacSecret:
+  annotations: {}
+
 serviceAccount:
   create: true
   # Annotations to add to the service account
@@ -48,6 +51,9 @@ wizConnector:
   tunnelServerAddress: ""
   tunnelServerPort: ""
   httpProxy: ""
+  # Annotation to be set on the secret created
+  secret:
+    annotations: {}
 
 # optional arguments
 secretName:

--- a/wiz-kubernetes-connector/Chart.yaml
+++ b/wiz-kubernetes-connector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wiz-kubernetes-connector/templates/secret-proxy.yaml
+++ b/wiz-kubernetes-connector/templates/secret-proxy.yaml
@@ -6,6 +6,10 @@ type: Opaque
 metadata:
   name: {{ include "wiz-kubernetes-connector.proxySecretName" . | trim }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- with .Values.httpProxyConfiguration.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "wiz-kubernetes-connector.labels" . | nindent 4 }}
 data:

--- a/wiz-kubernetes-connector/templates/secrets.yaml
+++ b/wiz-kubernetes-connector/templates/secrets.yaml
@@ -10,6 +10,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
+    {{- with .Values.wizConnector.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 stringData:
   {{- include "wiz-kubernetes-connector.wizConnectorSecretData" . | nindent 2 }}
@@ -29,6 +32,9 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
     "helm.sh/hook-weight": "-1"
+    {{- with .Values.wizApiToken.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   clientId: {{ required "Missing required value wizApiToken.clientId is required" .Values.wizApiToken.clientId | b64enc | quote }}
   clientToken: {{ required "Missing required value: wizApiToken.clientToken is required" .Values.wizApiToken.clientToken | b64enc | quote }}

--- a/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
+++ b/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
@@ -23,6 +23,9 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     kubernetes.io/service-account.name: {{ .Values.clusterReader.serviceAccount.name }}
+    {{- with .Values.clusterReader.secret.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/wiz-kubernetes-connector/values.yaml
+++ b/wiz-kubernetes-connector/values.yaml
@@ -19,7 +19,10 @@ clusterReader:
     annotations: {}
     # The name of the service account to use.
     name: "wiz-cluster-reader"
-  
+  secret:
+    # Annotations to add to the secret
+    annotations: {}
+
 autoCreateConnector:
   enabled: true
 
@@ -39,6 +42,8 @@ wizApiToken:
   # Specifies whether an api token secret should be created
   # If create is false you need to create it with clientId, clientToken
   createSecret: true
+  # Annotations to add to the secret
+  annotations: {}
   # The name of the secret to use.
   # If not set, a name is generated using the fullname template
   name: ""
@@ -54,6 +59,8 @@ wizConnector: # Relevant only for broker.enabled = true & autoCreateConnector = 
   #     CONNECTOR_ID, CONNECTOR_TOKEN, TARGET_DOMAIN, TARGET_IP, TARGET_PORT
   #  2. Set secretName to reference your secret
   createSecret: true
+  # Annotations to add to the secret
+  annotations: {}
   secretName: ""
 
   # Required arguments for autoCreateConnector = false
@@ -92,6 +99,7 @@ httpProxyConfiguration:
   #  1. Create secret with httpProxy, httpsProxy and noProxyAddress.
   #  2. Set secretName to reference your secret
   create: true
+  annotations: {}
   secretName: "" # Overriding default name for proxy secret name (.Release.Name + "-proxy-configuration" by default)
   
   httpProxy: "" # http(s)://user:password@your-proxy:port (user, password and port are optional)


### PR DESCRIPTION
Annotations on secrets could be useful when using an external secret manager (such as [Vault Mutating Webhook](https://banzaicloud.com/docs/bank-vaults/mutating-webhook/)).

Note that the new version numbers will voluntary conflict with the PR that adds common labels (https://github.com/wiz-sec/charts/pull/71), so that you can merge them in the order you prefer (I will update the version numbers accordingly)  